### PR TITLE
Yet another fix

### DIFF
--- a/WhiskWork.Web.UnitTest/JsonRendererTest.cs
+++ b/WhiskWork.Web.UnitTest/JsonRendererTest.cs
@@ -150,7 +150,7 @@ namespace WhiskWork.Web.UnitTest
 
             var json = GetJson(WorkStep.Root);
 
-            Assert.AreEqual("[{\"workstep\":\"analysis\",\"workitemList\":[{\"id\":\"cr1\",\"prop\":\"va\\x22l\\x22ue\"}]}]", json);
+            Assert.AreEqual("[{\"workstep\":\"analysis\",\"workitemList\":[{\"id\":\"cr1\",\"prop\":\"va\\u0022l\\u0022ue\"}]}]", json);
    
         }
 

--- a/WhiskWork.Web/JsonRenderer.cs
+++ b/WhiskWork.Web/JsonRenderer.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Security.Application;
 using WhiskWork.Core;
 using System.Web;
@@ -151,7 +152,7 @@ namespace WhiskWork.Web
 
         private static string Encode(string value)
         {
-            return AntiXss.JavaScriptEncode(value, false);
+            return Regex.Replace(AntiXss.JavaScriptEncode(value, false), @"(?<!\\)\\[x]([0-9]{2})", "\\u00$1");
         }
 
         private void RenderTransientWorkSteps(WorkStep step, TextWriter writer, WorkItem workItem)


### PR DESCRIPTION
AntiXss is using hex encoding for characters below 127, but JSON requires unicode encoding.
